### PR TITLE
Bug with original_file, for jpg, with s3 as storage. original file can't be read...

### DIFF
--- a/lib/paperclip-aws.rb
+++ b/lib/paperclip-aws.rb
@@ -138,7 +138,7 @@ module Paperclip
             log("saving #{path(style)}")
             
             @s3.buckets[@s3_bucket].objects[path(style)].write(
-              file,
+              :file => file.path,
               :acl => @s3_permissions[:style.to_sym] || @s3_permissions[:default],
               :storage_class => @s3_storage_class.to_sym,
               :content_type => file.content_type,


### PR DESCRIPTION
Hi, we faced an issue :
- for original file
- with JGP files only (PNG/GIF were OK)
- with AWS s3 as storage

the original file could not be read...

I don't really know why, but this small change fix this issue.
Loot at aws-sdk-for-ruby/lib/aws/s3/s3_object.rb... i'm not sure the "kind of" file stream given to write method was good. So i used a path.
