### PR TITLE
Fix for the undefined method `s3_credentials` for Hash

### DIFF
--- a/lib/paperclip-aws.rb
+++ b/lib/paperclip-aws.rb
@@ -24,7 +24,8 @@ module Paperclip
               :s3_headers,
               :bucket,
               :s3_options,
-              :s3_host_alias
+              :s3_host_alias,
+              :s3_protocol
             ].each do |meth|
               define_method(meth) { self[meth] || self[meth.to_s] } unless respond_to?(meth)
             end

--- a/lib/paperclip-aws.rb
+++ b/lib/paperclip-aws.rb
@@ -14,26 +14,38 @@ module Paperclip
           e.message << " (You may need to install the aws-sdk gem)"
           raise e
         end unless defined?(AWS)
-        
+
         attr_accessor :s3_options
         base.instance_eval do
 
-                   
+          class << @options
+            [ :s3_credentials,
+              :s3_permissions,
+              :s3_headers,
+              :bucket,
+              :s3_options,
+              :s3_host_alias
+            ].each do |meth|
+              define_method(meth) { self[meth] || self[meth.to_s] } unless respond_to?(meth)
+            end
+          end
+
+
           @s3_credentials = parse_credentials(@options.s3_credentials)
           @s3_permissions = set_permissions(@options.s3_permissions)
-          
+
           @s3_protocol    = @options.s3_protocol    ||
             Proc.new do |style, attachment|
               permission  = (@s3_permissions[style.to_sym] || @s3_permissions[:default])
               permission  = permission.call(attachment, style) if permission.is_a?(Proc)
               (permission == :public_read) ? 'http' : 'https'
             end
-          
+
           @s3_headers     = @options.s3_headers     || {}
-          
+
           @s3_bucket      = @options.bucket
-          @s3_bucket = @s3_bucket.call(self) if @s3_bucket.is_a?(Proc) 
-          
+          @s3_bucket = @s3_bucket.call(self) if @s3_bucket.is_a?(Proc)
+
           @s3_options     = @options.s3_options     || {}
           # setup Amazon Server Side encryption
           @s3_options.reverse_merge!({
@@ -41,45 +53,45 @@ module Paperclip
             :storage_class => :standard,
             :content_disposition => nil
           })
-          
+
           @s3_endpoint      = @s3_credentials[:endpoint] || 's3.amazonaws.com'
-                    
+
           @s3_host_alias    = @options.s3_host_alias
           @s3_host_alias    = @s3_host_alias.call(self) if @s3_host_alias.is_a?(Proc)
-                    
+
           @s3 = AWS::S3.new(
             :access_key_id => @s3_credentials[:access_key_id],
             :secret_access_key => @s3_credentials[:secret_access_key],
             :s3_endpoint => @s3_endpoint
           )
         end
-        
+
       end
-      
+
       def url(style=default_style, options={})
-        if self.original_filename.nil? 
+        if self.original_filename.nil?
           # default_url = @default_url.is_a?(Proc) ? @default_url.call(self) : @default_url
-          # return interpolate(default_url, style)          
+          # return interpolate(default_url, style)
           return super
         end
-        
+
         if options[:expires].present? || options[:action].present?
           options.reverse_merge!({
             :expires => 60*60,
             :action => :read
-          })          
-          secure = ( self.choose_protocol(style, options) == 'https' )                   
+          })
+          secure = ( self.choose_protocol(style, options) == 'https' )
           return @s3.buckets[@s3_bucket].objects[path(style).gsub(%r{^/}, "")].url_for(options[:action], {  :secure => secure, :expires => options[:expires] }).to_s
         else
           if @s3_host_alias.present?
             url = "#{choose_protocol(style, options)}://#{@s3_host_alias}/#{path(style).gsub(%r{^/}, "")}"
           else
             url = "#{choose_protocol(style, options)}://#{@s3_endpoint}/#{@s3_bucket}/#{path(style).gsub(%r{^/}, "")}"
-          end        
+          end
           return URI.escape(url)
-        end              
+        end
       end
-      
+
       def bucket_name
         @s3_bucket
       end
@@ -89,7 +101,7 @@ module Paperclip
         env = Object.const_defined?(:Rails) ? Rails.env : nil
         (creds[env] || creds).symbolize_keys
       end
-      
+
       def set_permissions permissions
         if permissions.is_a?(Hash)
           permissions[:default] = permissions[:default] || :public_read
@@ -140,7 +152,7 @@ module Paperclip
         @queued_for_write.each do |style, file|
           begin
             log("saving #{path(style)}")
-            
+
             @s3.buckets[@s3_bucket].objects[path(style)].write(
               :file => file.path,
               :acl => @s3_permissions[:style.to_sym] || @s3_permissions[:default],
@@ -188,3 +200,4 @@ module Paperclip
     end
   end
 end
+


### PR DESCRIPTION
I have added a fix for this error that appears due to changes in the Paperclip gem. Now the attachment options subclass Hash. 
