### PR TITLE
Ensuring that there is no newline at the end of the file content type

### DIFF
--- a/lib/paperclip-aws.rb
+++ b/lib/paperclip-aws.rb
@@ -104,7 +104,7 @@ module Paperclip
             self.s3.buckets[@s3_bucket].objects[path(style)].write({
               :file => file.path,
               :acl => @s3_permissions[:style.to_sym] || @s3_permissions[:default],
-              :content_type => file.content_type
+              :content_type => file.content_type.to_s.strip
             }.reverse_merge(@s3_options))
           rescue AWS::S3::Errors::NoSuchBucket => e
             create_bucket


### PR DESCRIPTION
I noticed that on some systems, a newline will be added to content_type, which causes the following error:

``` ruby
put_object(:acl=>"public-read",:bucket_name=>"mybucket",
:content_disposition=>nil,
:content_type=>"image/jpeg\n",   # <<<---- Here's the problem
:file=>"/tmp/stream2012-12012-0",:key=>"path/to/image.jpg",
:server_side_encryption=>false,
:storage_class=>:standard) 
AWS::S3::Errors::SignatureDoesNotMatch: The request signature we calculated does not match the signature you provided. Check your key and signing method.
```

I noticed that everywhere in the Paperclip libs (https://github.com/thoughtbot/paperclip/blob/master/lib/paperclip/attachment.rb#L113) they do the same thing.
